### PR TITLE
add user reset password feature

### DIFF
--- a/src/controllers/resetController.js
+++ b/src/controllers/resetController.js
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
 import models from '../models';
 import Mailer from '../services/mail/Mailer';
+import hash from '../utils/hash';
+import dbErrorHandler from '../utils/dbErrorHandler';
 
 const { User } = models;
 
@@ -50,6 +52,57 @@ class resetController {
           message: 'Link to reset password is sent to your email',
       });
    }
+
+     /**
+   * @description This is a function for sending email to a user with an account
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns  {object} The response object
+   */
+    static async resetPassword(req, res) {
+        const { 
+            password,
+            confirmPassword
+        } = req.body;
+
+        if (password !== confirmPassword) {
+            return res.status(400).json({
+                status: 400,
+                error: 'Password do not match!!',
+            });
+        }
+        const userEmail = req.params.email;
+        const exist = await User.findOne({
+            where: {
+                email: userEmail
+            }
+        });
+        if (exist) {
+            try {
+            const hashdPswd = await hash.hashPassword(password);
+            await User.update(
+                {
+                    password: hashdPswd
+                },
+                {
+                where: {
+                    email: userEmail
+                },
+                returning: false
+            });
+            return res.status(200).json({
+                status: 200,
+               message: 'Password is updated successfully', 
+            });
+        } catch (error) {
+             dbErrorHandler.handleSignupError(res, error);   
+        }
+        }
+        return res.status(404).json({
+            status: 404,
+            error: 'User with that email is not found',
+        });
+    }
 }
 
 export default resetController;

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -11,5 +11,6 @@ router.post('/signup', AuthMiddleware.signup, AuthenticationController.register)
 router.post('/verification/:emailToken', AuthenticationController.verifyingUsers);
 router.post('/login', LoginMiddleware.Validate, AuthenticationController.loginUser);
 router.post('/forgotPassword', validateEmail.forget, resetController.forgotPassword);
+router.patch('/resetPassword/:email/:password', validateEmail.reset, resetController.resetPassword);
 
 export default router;

--- a/src/test/reset.test.js
+++ b/src/test/reset.test.js
@@ -37,4 +37,45 @@ describe('User reset password test', () => {
         done();
       });
   });
+  it('should be able to reset password', done => {
+    chai.request(app)
+      .patch('/api/auth/resetPassword/tresorc@gmail.com/Bobo12345')
+      .send({ password: 'Bobobola123', confirmPassword: 'Bobobola123' })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.property('message', 'Password is updated successfully');
+        done();
+      });
+  });
+  it('should not be able to reset password if password do not match', done => {
+    chai.request(app)
+      .patch('/api/auth/resetPassword/tresorc@gmail.com/Bobo12345')
+      .send({ password: 'Bobobola123', confirmPassword: 'Bobobola123456' })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.have.property('error', 'Password do not match!!');
+        done();
+      });
+  });
+  it('should not be able to reset password if user does not exist', done => {
+    chai.request(app)
+      .patch('/api/auth/resetPassword/nivvhjvjv@gmail.com/Bobo12345')
+      .send({ password: 'Bobobola123', confirmPassword: 'Bobobola123' })
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.have.property('error', 'User with that email is not found');
+        done();
+      });
+  });
+  it('should not be able to reset password if there are validation errors', done => {
+    chai.request(app)
+      .patch('/api/auth/resetPassword/mhj@admin.com/Bobo12345')
+      .send({ password: 'Bobobola123' })
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.body.should.have.property('error');
+        done();
+      });
+  });
+
 });

--- a/src/test/verification.test.js
+++ b/src/test/verification.test.js
@@ -14,7 +14,7 @@ before('Signup', (done) => {
     .send({
       userName: 'eric',
       password: 'Ericeric1',
-      email: 'eric.mico6@gmail.com'
+      email: 'patrickishimwe@gmail.com'
     })
     .end((err, res) => {
       if (err) {


### PR DESCRIPTION
#### What does this PR do?
- This PR  is for adding a user reset password.
#### Description of Task to be completed?
- Create user reset password controller.
- Validate user inputs before anything else.
- Implement forgot password function and send the user a reset password email
- Implement the reset password function.
- Write tests
#### How should this be manually tested?
- Clone this repo to your local machine and go to `ft-reset-password`, run `npm install` to install the dependencies.
- Do `npm run dev` to start the app then go to the postman and use the following routes:
`http://localhost:5000/api/auth/forgotPassword` to perform forgot password
`/resetPassword/:email/:password` to perform reset password.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/83362282-5d0d6b00-a390-11ea-8f16-5479cdf8205f.png)
