### PR TITLE
adding user logout feature

### DIFF
--- a/src/controllers/authenticationController.js
+++ b/src/controllers/authenticationController.js
@@ -6,6 +6,8 @@ import Response from '../utils/response';
 import DbErrorHandler from '../utils/dbErrorHandler';
 import Mailer from '../services/mail/Mailer';
 import UserServices from '../services/user.service';
+import redisClient from '../database/redis.database';
+
 dotenv.config();
 
 const { User } = models;
@@ -138,5 +140,32 @@ export default class AuthenticationController {
             return res.status(500).json({ error: 'Internal Server Error', err });
         }
     }
+
+      /**
+   * @description contoller function that logs a user out
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @param {object} next - middleware object
+   * @returns {object} user - Logged in user
+   */
+
+   static async logout (req, res) {
+       try {
+           const token = req.headers.token || req.params.token;
+           if (!token) {
+            return res.status(403).json({
+                status: 403,
+                error: 'Provide token please!!',
+            });
+           }
+           redisClient.set('token', token);
+           return res.status(200).json({
+               status: 200,
+               message: 'You have logged out',
+           });
+       } catch (err) {
+        return res.status(500).json({ error: 'Internal Server Error', err });
+       }
+   }
 
 }

--- a/src/database/redis.database.js
+++ b/src/database/redis.database.js
@@ -1,0 +1,10 @@
+import dotenv from 'dotenv';
+import redis from 'redis';
+
+dotenv.config();
+
+const REDIS_PORT = process.env.PORT || 6379;
+
+const redisClient = redis.createClient(REDIS_PORT);
+
+export default redisClient;

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -4,6 +4,7 @@ import UserSchema from '../modules/userSchema';
 import validator from '../utils/validator';
 import AuthUtils from '../utils/auth.utils';
 import userRepository from '../repositories/userRepository';
+import redisClient from '../database/redis.database';
 
 const { trimmer } = validator;
 
@@ -20,7 +21,7 @@ class AuthMiddleware {
    */
   static async verifyToken(req, res, next) {
     try {
-      const token = (!req.headers.token) ? req.query.token.split(' ')[1] : req.headers.token.split(' ')[1];
+      const token = (!req.headers.token) ? req.query.token : req.headers.token;
       const payload = AuthUtils.jwtVerify(token);
       redisClient.get('token', (err, userToken) => {
         const user = userRepository.findByEmail(payload.email);

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -12,5 +12,6 @@ router.post('/verification/:emailToken', AuthenticationController.verifyingUsers
 router.post('/login', LoginMiddleware.Validate, AuthenticationController.loginUser);
 router.post('/forgotPassword', validateEmail.forget, resetController.forgotPassword);
 router.patch('/resetPassword/:email/:password', validateEmail.reset, resetController.resetPassword);
+router.get('/logout', AuthMiddleware.verifyToken, AuthenticationController.logout);
 
 export default router;

--- a/src/test/logout.test.js
+++ b/src/test/logout.test.js
@@ -1,0 +1,50 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+
+chai.use(chaiHttp);
+const { request } = chai;
+const logoutUrl = '/api/auth/logout';
+let token2;
+
+before((done) => {
+  request(app)
+    .post('/api/auth/signup')
+    .set('Accept', 'application/json')
+    .send({
+      userName: 'Tesi',
+      password: 'Fantastic7',
+      email: 'tesi1@admin.com'
+    })
+    .end((err, res) => {
+      const { token } = res.body.data;
+      token2 = token;
+      done();
+    });
+});
+it('should logout a logged in user', (done) => {
+  request(app)
+    .get(logoutUrl)
+    .set('Accept', 'application/json')
+    .set('token', `${token2}`)
+    .end((err, res) => {
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.property('message');
+      expect(res.body.status).to.eq(200);
+      expect(res.body.message).to.eq('You have logged out');
+      done();
+    });
+});
+it('should return an error if token is not provided', (done) => {
+  request(app)
+    .get(logoutUrl)
+    .set('Accept', 'application/json')
+    .end((err, res) => {
+      expect(res.status).to.equal(400);
+      expect(res.body).to.have.property('error');
+      expect(res.body.status).to.eq(400);
+      expect(res.body.error).to.eq('invalid token');
+      done();
+    });
+});
+


### PR DESCRIPTION
#### What does this PR do?
- This PR is for user logout function
#### Description of Task to be completed?
- Download, install, and configure Redis, to be able to use sessions.
- Create a user logout function in Auth Controller.
- Write tests
#### How should this be manually tested?
- Clone this repo to your local machine and go to the `ft-user-logout` branch, run `npm i` to install all dependencies.
- Run `npm run dev ` and the go-to `http://localhost:5000/api/auth/logout` using Postman.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/83634159-5ce4b980-a5a2-11ea-81ac-bb68520bbb90.png)
