### PR TITLE
adding create incident feature

### DIFF
--- a/src/controllers/incidentController.js
+++ b/src/controllers/incidentController.js
@@ -1,0 +1,58 @@
+import dotenv from 'dotenv';
+import models from '../models';
+import DbErrorHandler from '../utils/dbErrorHandler';
+import Response, { onError, onSuccess } from '../utils/response';
+import IncidentRepository from '../repositories/incidentRepository';
+import IncidentService from '../services/incident.service';
+import ImageUploader from '../utils/imageUploader.util';
+
+dotenv.config();
+
+const { User, Incident } = models;
+
+class IncidentController {
+      /**
+     * @description This helps User to create new incident
+     * @param  {object} req - The incident object
+     * @param  {object} res - The incident object
+     * @returns {object} The response object
+     */
+
+     static async createIncident(req, res) {
+        let response;
+        const { incidentData, userData } = req;
+        try {
+          if (req.files && req.files.image) {
+            const images = Array.isArray(req.files.image) ? req.files.image : [req.files.image];
+            const imageUrl = await ImageUploader.uploadImage(images);
+            if (!imageUrl) {
+              response = new Response(res, 415, 'Please Upload a valid image');
+              return response.sendErrorMessage();
+            }
+            incidentData.image_url = imageUrl[0];
+          }
+          const id = userData.id;
+          const user = await User.findOne({
+              where: {
+                  id
+              }
+          });
+          const { dataValues } = await Incident.create({ ...incidentData, 
+            user_id: userData.id,  user_FirstName: user.firstName, 
+            user_LastName: user.lastName});
+          if (dataValues) {
+            response = new Response(
+              res,
+              201,
+              'Your request to create an incident has been sent successfully, wait for approval',
+              dataValues
+            );
+            return response.sendSuccessResponse();
+          }
+        } catch (error) {
+          return DbErrorHandler.handleSignupError(res, error);
+        }
+}
+}
+
+export default IncidentController;

--- a/src/database/migrations/20200527101607-create-user.js
+++ b/src/database/migrations/20200527101607-create-user.js
@@ -66,7 +66,6 @@ module.exports = {
       }
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('Users');
-  }
+  down: queryInterface => queryInterface.dropTable('Users')
+
 };

--- a/src/database/migrations/20200605115333-create-incident.js
+++ b/src/database/migrations/20200605115333-create-incident.js
@@ -1,0 +1,65 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Incidents', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user_id: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'user_id',
+      },
+    },
+    user_FirstName: {
+      type: Sequelize.STRING,
+      allowNull: true,
+    },
+    user_LastName: {
+      type: Sequelize.STRING,
+      allowNull: true,
+    },
+    title: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    body: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    image_url: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    category: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    isApproved: {
+      allowNull: true,
+      type: Sequelize.BOOLEAN,
+      defaultValue: false
+    },
+    status: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'Pending'
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('NOW')
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('NOW')
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Incidents')
+};

--- a/src/database/seeders/20200527103323-create-user.js
+++ b/src/database/seeders/20200527103323-create-user.js
@@ -21,6 +21,15 @@ export default {
     password: await hashPassword('Kemmy123'),
     isVerified: true
   },
+  {
+  email: 'esperanceny@gmail.com',
+  user_name: 'Espe',
+  firstName: 'Esperance',
+  lastName: 'Nyampinga',
+  role: 'requester',
+  password: await hashPassword('Esperance12'),
+  isVerified: true
+},
   ], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Users', null, {})

--- a/src/database/seeders/20200605122821-create-incident.js
+++ b/src/database/seeders/20200605122821-create-incident.js
@@ -1,0 +1,21 @@
+export default {
+  up: queryInterface => queryInterface.bulkInsert('Incidents', [{
+    user_id: 3,
+    user_FirstName: 'Esperance',
+    user_LastName: 'Nyampinga',
+    title: 'Road fixing in Nyabihu',
+    body: 'Dear Government, Here in Nyabihu we need this road to be fixed',
+    category: 'Red flag',
+    status: 'Pending'
+  },
+  {
+    user_id: 2,
+    user_FirstName: 'Tresor',
+    user_LastName: 'Cyubahiro',
+    title: 'Domestic violance',
+    body: 'Dear Government, We would like you to intervene in a domestic violence case against Marie Uwamahoro here in Musanze',
+    category: 'Intervention',
+    status: 'Approved'
+  }], {}),
+  down: queryInterface => queryInterface.bulkDelete('Incidents', null, {})
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import authentication from './routes/authentication';
 import profile from './routes/profile.route';
+import incident from './routes/incident.route';
 
 export default (app) => {
     app.use('/api/auth', authentication);
     app.use('/api/profile', profile);
+    app.use('/api/incident', incident);
 
     app.use((req, res, next) => {
         const err = new Error('Page not found');

--- a/src/middlewares/incident.middleware.js
+++ b/src/middlewares/incident.middleware.js
@@ -1,0 +1,64 @@
+import 'dotenv';
+import Response from '../utils/response';
+import IncidentSchema from '../modules/incidentSchema';
+import validator from '../utils/validator';
+import AuthUtils from '../utils/auth.utils';
+
+const { trimmer } = validator;
+/**
+ * @description IncidentMiddleware checks if the param id is valid
+ */
+class IncidentMiddleware {
+  /**
+   * @param {req} req object
+   * @param {res} res object
+   * @param {next} next forwards incident to the next middleware function
+   * @returns {obj} returns a response object
+  */
+  static async param(req, res, next) {
+    const { error } = IncidentSchema.incidentParam(req.params);
+    try {
+      if (error) {
+        const response = new Response(res, 422, error.message);
+        return response.sendErrorMessage();
+      }
+
+      return next();
+    } catch (err) {
+      const response = new Response(res, 500, err || 'Internal server error');
+      return response.sendErrorMessage();
+    }
+  }
+
+  /**
+   * @param {req} req object
+   * @param {res} res object
+   * @param {next} next forwards incident to the next middleware function
+   * @returns {obj} returns a response object
+  */
+
+  static async validate(req, res, next) {
+    const { userData } = req;
+    const incidentData = trimmer(req.body);
+    const { error } = IncidentSchema.updateSchema(incidentData);
+    const verified = await AuthUtils.isVerified(userData);
+
+    if (!verified) {
+      response = new Response(res, 400, 'Your account is not yet verified');
+      return response.sendErrorMessage();
+    }
+    try {
+      if (error) {
+        const response = new Response(res, 422, error.message);
+        return response.sendErrorMessage();
+      }
+      req.incidentData = incidentData;
+      return next();
+    } catch (err) {
+      const response = new Response(res, 500, err);
+      return response.sendErrorMessage();
+    }
+  }
+}
+
+export default IncidentMiddleware;

--- a/src/models/incident.js
+++ b/src/models/incident.js
@@ -1,0 +1,82 @@
+export default (sequelize, DataTypes) => {
+  const Incident = sequelize.define(
+    'Incident',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+        type: DataTypes.INTEGER
+      },
+      user_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        onDelete: 'CASCADE',
+        references: {
+          model: 'Users',
+          key: 'id',
+          as: 'user_id',
+        },
+      },
+      user_FirstName: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      user_LastName: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      body: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      image_url: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      category: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        validate: {
+          isIn: {
+            args: [['Red flag', 'Intervention']],
+            msg: 'Invalid Category, uses Red flag or Intervention only'
+          }
+        }
+      },
+      isApproved: {
+        allowNull: true,
+        type: DataTypes.BOOLEAN,
+        defaultValue: true
+      },
+      status: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        defaultValue: 'Pending',
+        validate: {
+          isIn: {
+            args: [['Pending', 'Approved', 'Rejected']],
+            msg: 'Invalid Status, uses Pending, Approved or Rejected only'
+          }
+        }
+      },
+      createdAt: {
+        allowNull: true,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: true,
+        type: DataTypes.DATE
+      }
+    }, {}
+  );
+  Incident.associate = models => {
+    Incident.belongsTo(models.User, { foreignKey: 'user_id', as: 'user' });
+  };
+
+  return Incident;
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -71,8 +71,8 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false
     },
   }, {});
-  User.associate = function(models) {
-    // associations can be defined here
+  User.associate = models => {
+    User.hasMany(models.Incident, { foreignKey: 'user_id', as: 'incidents' });
   };
   return User;
 };

--- a/src/modules/incidentSchema.js
+++ b/src/modules/incidentSchema.js
@@ -1,0 +1,90 @@
+import Joi from '@hapi/joi';
+
+/**
+ * @description IncidentSchema class validates user data
+*/
+class IncidentSchema {
+  /**
+   * @static
+   * @param {obj} data
+   * @returns {obj} returns schema object
+  */
+  static incidentSchema(data) {
+    const schema = Joi.object().keys({
+      title: Joi.string().min(5).max(50)
+        .messages({
+          'string.base': 'Title must be a string',
+          'string.min': 'Title length must be at least {{#limit}} characters long',
+          'string.max': 'Title length must be less than or equal to {{#limit}} characters long',
+        }),
+      body: Joi.string().min(10).max(255)
+        .messages({
+          'string.base': 'Body must be a string',
+          'string.min': 'Body length must be at least {{#limit}} characters long',
+          'string.max': 'Body length must be less than or equal to {{#limit}} characters long',
+        }),
+      category: Joi.string().regex(/^(Red flag|Intervention|RED FLAG|INTERVENTION|red flag|intervention)$/)
+        .messages({
+          'string.base': 'category must be a string',
+          'string.pattern.base': 'category must be Red flag|Intervention|RED FLAG|INTERVENTION|red flag|intervention',
+        })
+    });
+    return schema.validate(data);
+  }
+
+  /**
+   * @static
+   * @param {obj} data
+   * @returns {obj} returns schema object
+  */
+  static updateSchema(data) {
+    const schema = Joi.object().keys({
+      title: Joi.string().min(5).max(50)
+        .messages({
+          'string.base': 'Title must be a string',
+          'string.min': 'Title length must be at least {{#limit}} characters long',
+          'string.max': 'Title length must be less than or equal to {{#limit}} characters long',
+        }),
+      body: Joi.string().min(10).max(255)
+        .messages({
+          'string.base': 'Body must be a string',
+          'string.min': 'Body length must be at least {{#limit}} characters long',
+          'string.max': 'Body length must be less than or equal to {{#limit}} characters long',
+        }),
+      category: Joi.string().regex(/^(Red flag|Intervention|RED FLAG|INTERVENTION|red flag|intervention)$/)
+        .messages({
+          'string.base': 'category must be a string',
+          'string.pattern.base': 'category must be Red flag|Intervention|RED FLAG|INTERVENTION|red flag|intervention',
+        })
+    });
+    return schema.validate(data);
+  }
+
+    /**
+   * @static
+   * @param {obj} data
+   * @returns {obj} returns schema object
+   * This is used to validate parameters in URL
+  */
+  static incidentParam(data) {
+    const schema = Joi.object({
+      id: Joi.number()
+        .integer()
+        .positive()
+        .min(1)
+        .messages({
+          'number.base': 'Parameter id must be a number',
+          'string.min': 'Parameter id  length must be at least {{#limit}} characters long',
+          'number.integer': 'Parameter id  must be an integer',
+          'number.positive': 'Parameter id  must be a positive number',
+          'number.unsafe': 'Parameter id  must be a safe number',
+          'any.required': 'Parameter id  is required',
+        }),
+    });
+
+    return schema.validate(data);
+  }
+
+}
+
+export default IncidentSchema;

--- a/src/repositories/incidentRepository.js
+++ b/src/repositories/incidentRepository.js
@@ -1,0 +1,153 @@
+import { Op } from 'sequelize';
+import model from '../models';
+
+const { Incident, User } = model;
+/**
+ * @description IncidentRepository contains Incident repository
+ */
+class IncidentRepository {
+  /**
+   * @description findAll helps to find all incidents
+   * @param {obj} options
+   * @param {*} limit
+   * @param {*} offset
+   * @returns {*} requests
+   */
+  static async findAll(options = {}, limit, offset) {
+    try {
+      const incidents = await Incident.findAll({
+        where: options, limit: limit || null, offset: offset || 0, order: [['createdAt', 'DESC']]
+      });
+      return incidents;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description findByIds helps to find incident by array of ids
+   * @param {Array} arrayIds
+   * @param {obj} options
+   * @param {*} limit
+   * @param {*} offset
+   * @returns {*} requests
+   */
+  static async findByIds(arrayIds, options, limit, offset) {
+    try {
+      const incidents = await Incident.findAll({
+        where: { user_id: { [Op.in]: arrayIds }, ...options || { [Op.in]: ['Pending', 'Approved', 'Rejected'] } },
+        limit: limit || null,
+        offset: offset || 0,
+        order: [['createdAt', 'DESC']]
+      });
+
+      return incidents;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description findIncidentByTimeframe helps to find incident in a certain time frame
+   * @param {Array} arrayIds
+   * @param {Date} startDate
+   * @param {Date} endDate
+   * @returns {*} statistics
+   */
+  static async findIncidentByTimeframe(arrayIds, startDate, endDate) {
+    try {
+      const statistics = await Incident.count({
+        where: {
+          user_id: { [Op.in]: arrayIds },
+          createdAt: {
+            [Op.between]: [startDate, endDate]
+          }
+        },
+      });
+
+      return statistics;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description findByStatus helps to find incident by status
+   * @param {Integer} status
+   * @returns {*} requests
+   */
+  static async findByStatus(status) {
+    try {
+      const incidents = await Incident.findAll({ where: { status } });
+
+      return incidents;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @param {object} field
+   *
+   * @param {object} changes to update for user
+   *
+   * @returns {object} updated user
+   */
+
+  static async update(field, changes) {
+    try {
+      const record = await Incident.update(changes, { returning: true, plain: true, where: field });
+
+      return record;
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  /**
+     *
+     * @param {integer} id
+     * @returns {obj} record is object if id found or null if not
+     */
+  static async findById(id) {
+    try {
+      const record = await Incident.findByPk(id, { include: [{ model: User, as: 'user' }] });
+
+      return record;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+     *
+     * @param {obj} options
+     * @returns {obj} record is object if match options
+     */
+  static async findOne(options) {
+    try {
+      const record = await Incident.findOne({ where: { ...options } });
+
+      return record;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+     *
+     * @param {obj} id
+     * @returns {obj} record is object if match options
+     */
+  static async findRequestById(id) {
+    try {
+      const record = await Incident.findOne({ where: { id }, include: [{ model: User, as: 'user' }] });
+
+      return record;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+}
+
+export default IncidentRepository;

--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import connect from 'connect-multiparty';
+import AuthMiddleware from '../middlewares/auth.middleware';
+import IncidentController from '../controllers/incidentController';
+import IncidentMiddleware from '../middlewares/incident.middleware';
+
+const router = express.Router();
+const connection = connect();
+router.post('/create', AuthMiddleware.verifyToken, connection, IncidentMiddleware.validate, IncidentController.createIncident);
+
+export default router;

--- a/src/services/incident.service.js
+++ b/src/services/incident.service.js
@@ -1,0 +1,67 @@
+import IncidentRepository from '../repositories/incidentRepository';
+
+class IncidentService {
+  /**
+   * @description retrieveAllIncidents helps to find all incidents
+   * @param {obj} options
+   * @param {*} limit
+   * @param {*} offset
+   * @returns {*} incidents
+   */
+  static async retrieveAllIncidents(options, limit, offset) {
+    try {
+      const incidents = await IncidentRepository.findAll(options, limit, offset);
+
+      return incidents;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description retrieveOneIncident helps to find incidents by id
+   * @param {*} options
+   * @returns {*} incident
+   */
+  static async retrieveOneIncident(options) {
+    try {
+      const incident = await IncidentRepository.findOne(options);
+
+      return incident;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * @description approveIncident helps to approve incident by id
+   * @param {*} id
+   * @returns {*} incident
+   */
+  static async approveIncident(id) {
+    try {
+      const incident = await IncidentRepository.update({ id }, { status: 'Approved' });
+
+      return incident;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+    /**
+   * @description rejectIncident helps to reject incident by id
+   * @param {*} id
+   * @returns {*} incident
+   */
+  static async rejectIncident() {
+    try {
+        const incident = await IncidentRepository.update({ id }, { status: 'Rejected'});
+
+        return incident;
+    } catch (error) {
+        throw new Error(error);
+    }
+  }
+}
+
+export default IncidentService;

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -1,0 +1,83 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+
+chai.use(chaiHttp);
+const { request } = chai;
+
+let token1;
+
+before((done) => {
+    request(app)
+      .post('/api/auth/login')
+      .set('Accept', 'application/json')
+      .send({
+        email: 'tresorc@gmail.com',
+        password: 'Kemmy123'
+      })
+      .end((err, res) => {
+        const { token } = res.body.data;
+        token1 = token;
+        done();
+      });
+  });
+
+  it('Should create new incident', (done) => {
+    request(app)
+      .post('/api/incident/create')
+      .set('Accept', 'application/json')
+      .set('token', `${token1}`)
+      .field('title', 'Mituelle')
+      .field('body', 'Dear government help us and donate mituelle to these families')
+      .field('category', 'Intervention')
+      .attach('image', 'src/test/assets/image.png', 'image.png')
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res).to.have.status(201);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.a.property('data');
+        return done();
+      });
+  });
+
+  it('Should not create new incident if inputs are invalid', (done) => {
+    request(app)
+      .post('/api/incident/create')
+      .set('Accept', 'application/json')
+      .set('token', `${token1}`)
+      .field('title', 'Mituelle')
+      .field('body', 'Dear government help us and donate mituelle to these families')
+      .field('category', 24)
+      .attach('image', 'src/test/assets/image.png', 'image.png')
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res).to.have.status(422);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.a.property('error');
+        return done();
+      });
+  });
+
+  it('Should not create new incident if image is invalid', (done) => {
+    request(app)
+      .post('/api/incident/create')
+      .set('Accept', 'application/json')
+      .set('token', `${token1}`)
+      .field('title', 'Corruption')
+      .field('body', 'Dear government help us and provide justice to Marie clire')
+      .field('category', 'Red flag')
+      .attach('image', 'src/test/assets/invalid.pdf', 'invalid.pdf')
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res).to.have.status(415);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.a.property('error');
+        return done();
+      });
+  });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -5,6 +5,7 @@ import login from './login.test';
 import reset from './reset.test';
 import assignRole from './assignRole.test';
 import profile from './profile.test';
+import incident from './incident.test';
 
 describe('API test', () => {
     describe('Register test', auth);
@@ -14,6 +15,7 @@ describe('API test', () => {
     describe('User forgot and reset password test', reset);
     describe('Change user role by admin test', assignRole);
     describe('User update profile tests', profile);
+    describe('User create new  incident tests', incident);
     
   });
   


### PR DESCRIPTION
#### What does this PR do?
- This PR is for create a new incident.
#### Description of Task to be completed?
- Create new incident table, migrate and seed the DB.
- Create a new incident controller, check if the user is verified.
- Validate user inputs, use Cloudinary to manipulate image and video files, then save the new incident.
- Write tests for this feature.
#### How should this be manually tested?
- Clone this repo to your local machine, go to the `ft-create-incident` branch and run `npm install` to install all dependencies.
- Run `npm run dev` then use Postman app to test this endpoint.
- Go to this route to test it `http://localhost:5000/api/incident/create`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84182720-24098080-aa8b-11ea-9f2e-7bb5233b2852.png)
