### PR TITLE
adding user delete incident

### DIFF
--- a/src/controllers/incidentController.js
+++ b/src/controllers/incidentController.js
@@ -86,6 +86,47 @@ class IncidentController {
            return DbErrorHandler.handleSignupError(res, error);
        }
    }
+
+     /**
+   * @description This helps user to delete unwanted incident
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns  {object} The response object
+   */
+
+   static async removeIncident(req, res) {
+    try {
+      const { userData } = req;
+      const isAdmin = await AuthUtils.isAdmin(userData);
+      const isRequester = await AuthUtils.isRequester(userData);
+      const id = parseInt(req.params.id);
+      if (isAdmin) {
+        const incident = await IncidentService.retrieveOneIncident({ id });
+        if (!incident) {
+          return onError(res, 404, 'Sorry, Incident not found');
+        }
+        const result = await IncidentRepository.deleteIncident(id);
+        if (result) {
+          return onSuccess(res, 200, 'Incident sucessfully deleted');
+        }
+      }
+      if (isRequester) {
+        const incident = await IncidentService.retrieveOneIncident({ id });
+        if (!incident) {
+          return onError(res, 404, 'Sorry, Incident not found');
+        }
+        if (incident.user_id !== userData.id) {
+          return onError(res, 401, 'This incident does not belong to you ');
+        }
+        const result = await IncidentRepository.deleteIncident(id);
+        if (result) {
+          return onSuccess(res, 200, 'Incident sucessfully deleted');
+        }
+      }
+    } catch (error) {
+      return DbErrorHandler.handleSignupError(res, error);
+    }
+   }
 }
 
 export default IncidentController;

--- a/src/database/seeders/20200605122821-create-incident.js
+++ b/src/database/seeders/20200605122821-create-incident.js
@@ -16,6 +16,15 @@ export default {
     body: 'Dear Government, We would like you to intervene in a domestic violence case against Marie Uwamahoro here in Musanze',
     category: 'Intervention',
     status: 'Approved'
+  },
+  {
+    user_id: 2,
+    user_FirstName: 'Tresor',
+    user_LastName: 'Cyubahiro',
+    title: 'Mituelle fund raising',
+    body: 'Dear Government, In nyamabuye sector we wanted to doa fund raising for 200 hundred families and provide mituelle cards for them',
+    category: 'Intervention',
+    status: 'Pending'
   }], {}),
   down: queryInterface => queryInterface.bulkDelete('Incidents', null, {})
 };

--- a/src/repositories/incidentRepository.js
+++ b/src/repositories/incidentRepository.js
@@ -148,6 +148,21 @@ class IncidentRepository {
       throw new Error(error);
     }
   }
+
+    /**
+   * Gets comment by id.
+   * @param {object} id .
+   * @returns {object} delete object.
+   */
+  static async deleteIncident(id) {
+    try {
+      return await Incident.destroy({
+        where: [{ id }]
+      });
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
 }
 
 export default IncidentRepository;

--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -9,5 +9,6 @@ const connection = connect();
 
 router.post('/create', AuthMiddleware.verifyToken, connection, IncidentMiddleware.validate, IncidentController.createIncident);
 router.get('/viewAll', AuthMiddleware.verifyToken, IncidentController.getAll);
+router.delete('/:id/delete', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.removeIncident);
 
 export default router;

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -113,6 +113,8 @@ before((done) => {
         return done();
       });
   });
+  
+  // VIEW ALL INCIDENTS TESTS
 
   it('Should return all incidents that belong to user', (done) => {
     request(app)
@@ -139,6 +141,59 @@ before((done) => {
             return done();
           });
         });
+
+        // DELETE INCIDENTS TESTS
+        it('Should delete incident if the user created it', (done) => {
+          request(app)
+            .delete('/api/incident/2/delete')
+            .set('Accept', 'application/json')
+            .set('token', `${token1}`)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.be.an('object');
+              expect(res.body).to.have.a.property('message');
+              return done();
+            });
+          });
+
+          it('Should not delete if not found', (done) => {
+            request(app)
+              .delete('/api/incident/10/delete')
+              .set('Accept', 'application/json')
+              .set('token', `${token1}`)
+              .then(res => {
+                expect(res).to.have.status(404);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.a.property('error');
+                return done();
+              });
+            });
+
+            it('Should not delete if not created by', (done) => {
+              request(app)
+                .delete('/api/incident/1/delete')
+                .set('Accept', 'application/json')
+                .set('token', `${token3}`)
+                .then(res => {
+                  expect(res).to.have.status(401);
+                  expect(res.body).to.be.an('object');
+                  expect(res.body).to.have.a.property('error');
+                  return done();
+                });
+              });
+
+          it('Should delete incident if Administrator', (done) => {
+            request(app)
+              .delete('/api/incident/3/delete')
+              .set('Accept', 'application/json')
+              .set('token', `${token2}`)
+              .then(res => {
+                expect(res).to.have.status(200);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.a.property('message');
+                return done();
+              });
+            });
 
 describe('Admin incident tests', () => {
     it('Should return all incidents', (done) => {


### PR DESCRIPTION
#### What does this PR do?
- This PR  allows users to delete a specific incident.
#### Description of Task to be completed?
- Create new `deleteIncident()` function..
- Verify the user token, check if the user is an `administrator` delete incident if the user is `requester` delete an incident he or she has created.
- Check the URL parameters and verify them.
- Write tests for the function.
#### How should this be manually tested?
- Clone this repo to your local machine, then go to `ft-delete-incident`, run `npm install` to install all dependencies.
- Run `npm run dev` to start the app and then go to `http://localhost:5000/api/incident/:id/delete` to test the endpoint.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84270084-6a61ec80-ab2a-11ea-9483-a9524ee20531.png)
