### PR TITLE
add view specific incident

### DIFF
--- a/src/controllers/incidentController.js
+++ b/src/controllers/incidentController.js
@@ -127,6 +127,41 @@ class IncidentController {
       return DbErrorHandler.handleSignupError(res, error);
     }
    }
+
+     /**
+   * @description This helps to find incident by id
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns  {object} The response object
+   */
+
+    static async getOne(req, res) {
+      let incident;
+      let response;
+
+      try {
+        const { userData } = req;
+        const id =  parseInt(req.params.id);
+        const isAdmin = await AuthUtils.isAdmin(userData);
+        const isRequester = await AuthUtils.isRequester(userData);
+
+        if (isAdmin) {
+         incident = await IncidentService.retrieveOneIncident({ id });
+        }
+        if (isRequester) {
+          incident = await IncidentService.retrieveOneIncident({ user_id: userData.id, id});
+        }
+
+        if (!incident) {
+          response = new Response(res, 404, 'Sorry, Incident not found');
+          return response.sendErrorMessage();
+        }
+        response = new Response(res, 200, 'Found Incident', incident);
+        return response.sendSuccessResponse();
+      } catch (error) {
+        return DbErrorHandler.handleSignupError(res, error);
+      }
+    }
 }
 
 export default IncidentController;

--- a/src/models/incident.js
+++ b/src/models/incident.js
@@ -51,7 +51,7 @@ export default (sequelize, DataTypes) => {
       isApproved: {
         allowNull: true,
         type: DataTypes.BOOLEAN,
-        defaultValue: true
+        defaultValue: false
       },
       status: {
         type: DataTypes.STRING,

--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -10,5 +10,6 @@ const connection = connect();
 router.post('/create', AuthMiddleware.verifyToken, connection, IncidentMiddleware.validate, IncidentController.createIncident);
 router.get('/viewAll', AuthMiddleware.verifyToken, IncidentController.getAll);
 router.delete('/:id/delete', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.removeIncident);
+router.get('/:id', AuthMiddleware.verifyToken, IncidentController.getOne);
 
 export default router;

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -142,6 +142,61 @@ before((done) => {
           });
         });
 
+        // FIND SPECIFIC INCIDENT TESTS
+        it('Should find incident if the user created it', (done) => {
+          request(app)
+            .get('/api/incident/2')
+            .set('Accept', 'application/json')
+            .set('token', `${token1}`)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.be.an('object');
+              expect(res.body).to.have.a.property('message');
+              expect(res.body).to.have.a.property('data');
+              return done();
+            });
+          });
+
+          it('Should not find specific incident if not found', (done) => {
+            request(app)
+              .get('/api/incident/10')
+              .set('Accept', 'application/json')
+              .set('token', `${token1}`)
+              .then(res => {
+                expect(res).to.have.status(404);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.a.property('error');
+                return done();
+              });
+            });
+
+            it('Should not find specific incident if not created by', (done) => {
+              request(app)
+                .get('/api/incident/1')
+                .set('Accept', 'application/json')
+                .set('token', `${token3}`)
+                .then(res => {
+                  expect(res).to.have.status(404);
+                  expect(res.body).to.be.an('object');
+                  expect(res.body).to.have.a.property('error');
+                  return done();
+                });
+              });
+
+              it('Should find incident if Administrator', (done) => {
+                request(app)
+                  .get('/api/incident/3')
+                  .set('Accept', 'application/json')
+                  .set('token', `${token2}`)
+                  .then(res => {
+                    expect(res).to.have.status(200);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body).to.have.a.property('message');
+                    expect(res.body).to.have.a.property('data');
+                    return done();
+                  });
+                });
+
         // DELETE INCIDENTS TESTS
         it('Should delete incident if the user created it', (done) => {
           request(app)


### PR DESCRIPTION
#### What does this PR do?
- This PR  allows users to view a specific incident.
#### Description of Task to be completed?
- Create view single incident function.
- Verify user token, if the user is `Administrator`, let them view the requested incident
If the user `Requester`, let them view the requested incident if they are the creator.
- Write tests
#### How should this be manually tested?
- Clone this repo to your local machine, go to `ft-view-specific-incident` and run `npm install` to install all the dependencies.
- Run `npm run dev` to start the app and use the Postman app to test the endpoint.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84298763-ede20480-ab4f-11ea-8a69-ce3fccc155d2.png)
