### PR TITLE
add user find incident by status

### DIFF
--- a/src/controllers/incidentController.js
+++ b/src/controllers/incidentController.js
@@ -162,6 +162,43 @@ class IncidentController {
         return DbErrorHandler.handleSignupError(res, error);
       }
     }
+
+      /**
+   * @description This helps to find all pending requests
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns  {object} The response object
+   */
+      static async getByStatus(req, res) {
+        let incidents;
+        let response;
+
+        try {
+          const { userData } = req;
+          const { value } =req.params;
+          const status = value.charAt(0).toUpperCase() + value.slice(1);
+
+          const isAdmin = await AuthUtils.isAdmin(userData);
+          const isRequester = await AuthUtils.isRequester(userData);
+           
+          if (isAdmin) {
+            incidents = await IncidentService.retrieveAllIncidents({ status });
+          }
+
+          if (isRequester) {
+            incidents =await IncidentService.
+            retrieveAllIncidents({ user_id: userData.id, status});
+          }
+          if (incidents.length === 0) {
+            response = new Response(res, 404, `Sorry, there are no ${status} incidents found`);
+            return response.sendErrorMessage();
+          }
+          response = new Response(res, 200, `All ${status} incidents`, incidents);
+          return response.sendSuccessResponse();
+        } catch (error) {
+          return DbErrorHandler.handleSignupError(res, error);
+        }
+      }
 }
 
 export default IncidentController;

--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -11,5 +11,7 @@ router.post('/create', AuthMiddleware.verifyToken, connection, IncidentMiddlewar
 router.get('/viewAll', AuthMiddleware.verifyToken, IncidentController.getAll);
 router.delete('/:id/delete', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.removeIncident);
 router.get('/:id', AuthMiddleware.verifyToken, IncidentController.getOne);
+router.get('/status/:value', AuthMiddleware.verifyToken, IncidentController.getByStatus);
+
 
 export default router;

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -197,6 +197,48 @@ before((done) => {
                   });
                 });
 
+                    // FIND INCIDENTS BY STATUS
+            it('Should find incident if the user created it', (done) => {
+              request(app)
+                .get('/api/incident/status/approved')
+                .set('Accept', 'application/json')
+                .set('token', `${token1}`)
+                .then(res => {
+                  expect(res).to.have.status(200);
+                  expect(res.body).to.be.an('object');
+                  expect(res.body).to.have.a.property('message');
+                  expect(res.body).to.have.a.property('data');
+                  return done();
+                });
+              });
+    
+              it('Should not find incident if not found', (done) => {
+                request(app)
+                  .get('/api/incident/status/rejected')
+                  .set('Accept', 'application/json')
+                  .set('token', `${token1}`)
+                  .then(res => {
+                    expect(res).to.have.status(404);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body).to.have.a.property('error');
+                    return done();
+                  });
+                });
+  
+                  it('Should find incident if Administrator', (done) => {
+                    request(app)
+                      .get('/api/incident/status/Pending')
+                      .set('Accept', 'application/json')
+                      .set('token', `${token2}`)
+                      .then(res => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.a.property('message');
+                        expect(res.body).to.have.a.property('data');
+                        return done();
+                      });
+                    });
+
         // DELETE INCIDENTS TESTS
         it('Should delete incident if the user created it', (done) => {
           request(app)


### PR DESCRIPTION
#### What does this PR do?
- This PR  allows users to find incidents by their status(Pending, Approved or Rejected).
#### Description of Task to be completed?
- Create find by status function.
- Verify the user token, if the user role is `Administrator`, show them all the found incidents in the database, else show them found incidents created by them.
- Write tests.
#### How should this be manually tested?
- Clone this repo to your local machine, go to `ft-get-by-status` and run `npm install` to install all the dependencies.
- Run `npm run dev` to run the app and use the Postman app to test the endpoint.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84306011-3652ef80-ab5b-11ea-805d-97ae45c22ec3.png)
![image](https://user-images.githubusercontent.com/52447234/84306180-7023f600-ab5b-11ea-830d-880f2f6eb6aa.png)
