### PR TITLE
adding approve incident

### DIFF
--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -10,8 +10,9 @@ const connection = connect();
 router.post('/create', AuthMiddleware.verifyToken, connection, IncidentMiddleware.validate, IncidentController.createIncident);
 router.get('/viewAll', AuthMiddleware.verifyToken, IncidentController.getAll);
 router.delete('/:id/delete', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.removeIncident);
-router.get('/:id', AuthMiddleware.verifyToken, IncidentController.getOne);
+router.get('/:id', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.getOne);
 router.get('/status/:value', AuthMiddleware.verifyToken, IncidentController.getByStatus);
+router.patch('/:id/approve', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.approve);
 
 
 export default router;

--- a/src/services/incident.service.js
+++ b/src/services/incident.service.js
@@ -40,7 +40,7 @@ class IncidentService {
    */
   static async approveIncident(id) {
     try {
-      const incident = await IncidentRepository.update({ id }, { status: 'Approved' });
+      const incident = await IncidentRepository.update({ id }, { status: 'Approved', isApproved: true });
 
       return incident;
     } catch (error) {

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -239,6 +239,58 @@ before((done) => {
                       });
                     });
 
+        //ADMIN APPROVE INCIDENT TESTS
+        it('Should approve incident, if Administrator and found', (done) => {
+          request(app)
+            .patch('/api/incident/1/approve')
+            .set('Accept', 'application/json')
+            .set('token', `${token2}`)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body).to.be.an('object');
+              expect(res.body).to.have.a.property('message');
+              expect(res.body).to.have.a.property('data');
+              return done();
+            });
+          });
+
+          it('Should not approve incident, if not found', (done) => {
+            request(app)
+              .patch('/api/incident/100/approve')
+              .set('Accept', 'application/json')
+              .set('token', `${token2}`)
+              .then(res => {
+                expect(res).to.have.status(404);
+                expect(res.body).to.be.an('object');
+                expect(res.body).to.have.a.property('error');
+                return done();
+              });
+            });
+            it('Should not approve incident, if approved already', (done) => {
+              request(app)
+                .patch('/api/incident/2/approve')
+                .set('Accept', 'application/json')
+                .set('token', `${token2}`)
+                .then(res => {
+                  expect(res).to.have.status(400);
+                  expect(res.body).to.be.an('object');
+                  expect(res.body).to.have.a.property('error');
+                  return done();
+                });
+              });
+              it('Should not approve incident, if not administrator', (done) => {
+                request(app)
+                  .patch('/api/incident/3/approve')
+                  .set('Accept', 'application/json')
+                  .set('token', `${token3}`)
+                  .then(res => {
+                    expect(res).to.have.status(401);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body).to.have.a.property('error');
+                    return done();
+                  });
+                });
+
         // DELETE INCIDENTS TESTS
         it('Should delete incident if the user created it', (done) => {
           request(app)


### PR DESCRIPTION
#### What does this PR do?
- This PR allows the administrator to approve an incident.
#### Description of Task to be completed?
- Create approve incident function.
- Verify user token and check the role, if it is `Administrator` let them approve the incident, if not deny em access.
- Check if the incident is not approved already and check if it exists.
- Write tests.
#### How should this be manually tested?
- Clone this repo to your local machine, and go to `ft-approve-incident` and run `npm install` to install all the dependencies.
- Run `npm run dev` to start the app and use the `Postman` app to test the endpoint.
- Use this route `http://localhost:5000/api/incident/2/approve`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84373346-bbcab400-abdc-11ea-83fa-e2c69c437dee.png)
