### PR TITLE
adding admin reject incident

### DIFF
--- a/src/controllers/incidentController.js
+++ b/src/controllers/incidentController.js
@@ -235,6 +235,42 @@ class IncidentController {
               return DbErrorHandler.handleSignupError(res, error);
             }
           }
+
+                  /**
+   * @description This helps the system admin to approve an incident
+   * @param  {object} req - The request object
+   * @param  {object} res - The response object
+   * @returns  {object} The response object
+   */
+  static async reject(req, res) {
+    let incident;
+    let response;
+    try {
+      const { userData } = req;
+      const id = parseInt(req.params.id);
+      const isAdmin = await AuthUtils.isAdmin(userData);
+
+      if (isAdmin) {
+        incident = await IncidentService.retrieveOneIncident({ id });
+        if (!incident) {
+          response = new Response(res, 404, 'Sorry, Incident not found');
+          return response.sendErrorMessage();
+        }
+        if (incident.status === 'Rejected') {
+          response = new Response(res, 400, 'Incident is already rejected');
+          return response.sendErrorMessage();
+        }
+        const rejectedIncident = await IncidentService.rejectIncident(id);
+        response = new Response(res, 200, 
+          'Incident is sucessfully approved', rejectedIncident[1]);
+        return response.sendSuccessResponse();
+      }
+      response = new Response(res, 401, 'Unauthorized access');
+      return response.sendErrorMessage();
+    } catch (error) {
+      return DbErrorHandler.handleSignupError(res, error);
+    }
+  }
 }
 
 export default IncidentController;

--- a/src/database/seeders/20200605122821-create-incident.js
+++ b/src/database/seeders/20200605122821-create-incident.js
@@ -25,6 +25,15 @@ export default {
     body: 'Dear Government, In nyamabuye sector we wanted to doa fund raising for 200 hundred families and provide mituelle cards for them',
     category: 'Intervention',
     status: 'Pending'
+  },
+  {
+    user_id: 3,
+    user_FirstName: 'Bora',
+    user_LastName: 'Rehema',
+    title: 'Info Technology',
+    body: 'Dear Government, as tech is evolving the young generation of Mutiba are in need of being a part of it. Please help provide them with Computers',
+    category: 'Red flag',
+    status: 'Pending'
   }], {}),
   down: queryInterface => queryInterface.bulkDelete('Incidents', null, {})
 };

--- a/src/routes/incident.route.js
+++ b/src/routes/incident.route.js
@@ -13,6 +13,7 @@ router.delete('/:id/delete', IncidentMiddleware.param, AuthMiddleware.verifyToke
 router.get('/:id', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.getOne);
 router.get('/status/:value', AuthMiddleware.verifyToken, IncidentController.getByStatus);
 router.patch('/:id/approve', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.approve);
+router.patch('/:id/reject', IncidentMiddleware.param, AuthMiddleware.verifyToken, IncidentController.reject);
 
 
 export default router;

--- a/src/services/incident.service.js
+++ b/src/services/incident.service.js
@@ -53,7 +53,7 @@ class IncidentService {
    * @param {*} id
    * @returns {*} incident
    */
-  static async rejectIncident() {
+  static async rejectIncident(id) {
     try {
         const incident = await IncidentRepository.update({ id }, { status: 'Rejected'});
 

--- a/src/test/incident.test.js
+++ b/src/test/incident.test.js
@@ -291,6 +291,58 @@ before((done) => {
                   });
                 });
 
+              //ADMINISTRATOR REJECT INCIDENT TEST
+                it('Should reject incident, if Administrator and found', (done) => {
+                  request(app)
+                    .patch('/api/incident/4/reject')
+                    .set('Accept', 'application/json')
+                    .set('token', `${token2}`)
+                    .then(res => {
+                      expect(res).to.have.status(200);
+                      expect(res.body).to.be.an('object');
+                      expect(res.body).to.have.a.property('message');
+                      expect(res.body).to.have.a.property('data');
+                      return done();
+                    });
+                  });
+        
+                  it('Should not reject incident, if not found', (done) => {
+                    request(app)
+                      .patch('/api/incident/100/reject')
+                      .set('Accept', 'application/json')
+                      .set('token', `${token2}`)
+                      .then(res => {
+                        expect(res).to.have.status(404);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.a.property('error');
+                        return done();
+                      });
+                    });
+                    it('Should not reject incident, if rejected already', (done) => {
+                      request(app)
+                        .patch('/api/incident/4/reject')
+                        .set('Accept', 'application/json')
+                        .set('token', `${token2}`)
+                        .then(res => {
+                          expect(res).to.have.status(400);
+                          expect(res.body).to.be.an('object');
+                          expect(res.body).to.have.a.property('error');
+                          return done();
+                        });
+                      });
+                      it('Should not reject incident, if not administrator', (done) => {
+                        request(app)
+                          .patch('/api/incident/3/reject')
+                          .set('Accept', 'application/json')
+                          .set('token', `${token3}`)
+                          .then(res => {
+                            expect(res).to.have.status(401);
+                            expect(res.body).to.be.an('object');
+                            expect(res.body).to.have.a.property('error');
+                            return done();
+                          });
+                        });
+
         // DELETE INCIDENTS TESTS
         it('Should delete incident if the user created it', (done) => {
           request(app)


### PR DESCRIPTION
#### What does this PR do?
- This PR  allows the Administrator to reject an incident.
#### Description of Task to be completed?
- Create a `reject incident function`.
- Verify user token, check the role, if `Administrator` allow them to reject incident if noot deny them access.
- Check if the incident is found and check if it is not rejected already.
- Write tests.
#### How should this be manually tested?
- Clone this repo to your local machine, go to `ft-reject-incident` and run `npm install` to install all the dependencies.
- Run `npm run dev` to start the app and use the `Postman` app to test the endpoint.
- Go to this route `http://localhost:5000/api/incident/:id/reject`.
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- N/A
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52447234/84377336-ba9c8580-abe2-11ea-964f-9fe5310acdf6.png)
![image](https://user-images.githubusercontent.com/52447234/84377701-575f2300-abe3-11ea-9fbc-4ae0ec04f039.png)
![image](https://user-images.githubusercontent.com/52447234/84377776-76f64b80-abe3-11ea-9dd2-bf7c31f879b2.png)
